### PR TITLE
Issue17

### DIFF
--- a/convert_fendl.py
+++ b/convert_fendl.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
 from pathlib import Path
 import ssl
 import subprocess

--- a/convert_tendl.py
+++ b/convert_tendl.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
-import os
+from pathlib import Path
 import sys
 import tarfile
 
@@ -27,7 +26,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('-b', '--batch', action='store_true',
                     help='supresses standard in')
-parser.add_argument('-d', '--destination', default=None,
+parser.add_argument('-d', '--destination', type=Path, default=None,
                     help='Directory to create new library in')
 parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='latest', help="Output HDF5 versioning. Use "
@@ -41,26 +40,26 @@ args = parser.parse_args()
 
 
 library_name = 'tendl' #this could be added as an argument to allow different libraries to be downloaded
-ace_files_dir = '-'.join([library_name, args.release, 'ace'])
+ace_files_dir = Path('-'.join([library_name, args.release, 'ace']))
 # the destination is decided after the release is know to avoid putting the release in a folder with a misleading name
 if args.destination is None:
-    args.destination = '-'.join([library_name, args.release, 'hdf5'])
+    args.destination = Path('-'.join([library_name, args.release, 'hdf5']))
 
 # This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
 release_details = {
     '2015': {
         'base_url': 'https://tendl.web.psi.ch/tendl_2015/tar_files/',
         'files': ['ACE-n.tgz'],
-        'neutron_files': os.path.join(ace_files_dir, 'neutron_file', '*', '*', 'lib', 'endf', '*-n.ace'),
-        'metastables': os.path.join(ace_files_dir, 'neutron_file', '*', '*', 'lib', 'endf', '*m-n.ace'),
+        'neutron_files': ace_files_dir.glob('neutron_file/*/*/lib/endf/*-n.ace'),
+        'metastables': ace_files_dir.glob('neutron_file/*/*/lib/endf/*m-n.ace'),
         'compressed_file_size': '5.1 GB',
         'uncompressed_file_size': '40 GB'
     },
     '2017': {
         'base_url': 'https://tendl.web.psi.ch/tendl_2017/tar_files/',
         'files': ['tendl17c.tar.bz2'],
-        'neutron_files': os.path.join(ace_files_dir, 'ace-17', '*'),
-        'metastables': os.path.join(ace_files_dir, 'ace-17', '*m'),
+        'neutron_files': ace_files_dir.glob('ace-17/*'),
+        'metastables': ace_files_dir.glob('ace-17/*m'),
         'compressed_file_size': '2.1 GB',
         'uncompressed_file_size': '14 GB'
     }
@@ -96,16 +95,14 @@ for f in release_details[args.release]['files']:
         continue
 
     # Extract files
-
-    suffix = ''
     with tarfile.open(f, 'r') as tgz:
         print('Extracting {0}...'.format(f))
-        tgz.extractall(path=os.path.join(ace_files_dir, suffix))
+        tgz.extractall(path=ace_files_dir)
 
 # ==============================================================================
 # CHANGE ZAID FOR METASTABLES
 
-metastables = glob.glob(release_details[args.release]['metastables'])
+metastables = release_details[args.release]['metastables']
 for path in metastables:
     print('    Fixing {} (ensure metastable)...'.format(path))
     text = open(path, 'r').read()
@@ -118,29 +115,28 @@ for path in metastables:
 # GENERATE HDF5 LIBRARY -- NEUTRON FILES
 
 # Get a list of all ACE files
-neutron_files = glob.glob(release_details[args.release]['neutron_files'])
+neutron_files = release_details[args.release]['neutron_files']
 
 # Create output directory if it doesn't exist
-if not os.path.isdir(args.destination):
-    os.mkdir(args.destination)
+args.destination.mkdir(parents=True, exist_ok=True)
 
 library = openmc.data.DataLibrary()
 
 for filename in sorted(neutron_files):
 
     # this is a fix for the TENDL-2017 release where the B10 ACE file which has an error on one of the values
-    if library_name == 'tendl' and args.release == '2017' and os.path.basename(filename) == 'B010':
+    if library_name == 'tendl' and args.release == '2017' and filename.name == 'B010':
         text = open(filename, 'r').read()
         if text[423:428] == '86843':
             print('Manual fix for incorrect value in ACE file') # see OpenMC user group issue for more details
             text = ''.join(text[:423])+'86896'+''.join(text[428:])
             open(filename, 'w').write(text)
 
-    print('Converting: ' + filename)
+    print('Converting: ' + str(filename))
     data = openmc.data.IncidentNeutron.from_ace(filename)
 
     # Export HDF5 file
-    h5_file = os.path.join(args.destination, data.name + '.h5')
+    h5_file = args.destination / f'{data.name}.h5'
     print('Writing {}...'.format(h5_file))
     data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
@@ -148,5 +144,4 @@ for filename in sorted(neutron_files):
     library.register_file(h5_file)
 
 # Write cross_sections.xml
-libpath = os.path.join(args.destination, 'cross_sections.xml')
-library.export_to_xml(libpath)
+library.export_to_xml(args.destination / 'cross_sections.xml')

--- a/generate_cendl.py
+++ b/generate_cendl.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
-import glob
-import os
+from pathlib import Path
 import sys
 import zipfile
 
@@ -27,7 +26,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('-b', '--batch', action='store_true',
                     help='supresses standard in')
-parser.add_argument('-d', '--destination', default=None,
+parser.add_argument('-d', '--destination', type=Path, default=None,
                     help='Directory to create new library in')
 parser.add_argument('--libver', choices=['earliest', 'latest'],
                     default='latest', help="Output HDF5 versioning. Use "
@@ -41,18 +40,18 @@ args = parser.parse_args()
 
 
 library_name = 'cendl' #this could be added as an argument to allow different libraries to be downloaded
-endf_files_dir = '-'.join([library_name, args.release, 'endf'])
+endf_files_dir = Path('-'.join([library_name, args.release, 'endf']))
 # the destination is decided after the release is known to avoid putting the release in a folder with a misleading name
 if args.destination is None:
-    args.destination = '-'.join([library_name, args.release, 'hdf5'])
+    args.destination = Path('-'.join([library_name, args.release, 'hdf5']))
 
 # This dictionary contains all the unique information about each release. This can be exstened to accommodated new releases
 release_details = {
     '3.1': {
         'base_url': 'https://www.oecd-nea.org/dbforms/data/eva/evatapes/cendl_31/',
         'files': ['CENDL-31.zip'],
-        'neutron_files': os.path.join(endf_files_dir, '*.C31'),
-        'metastables': os.path.join(endf_files_dir, '*m.C31'),
+        'neutron_files': endf_files_dir.glob('*.C31'),
+        'metastables': endf_files_dir.glob('*m.C31'),
         'compressed_file_size': '0.03 GB',
         'uncompressed_file_size': '0.4 GB'
     }
@@ -89,41 +88,39 @@ for f in release_details[args.release]['files']:
 
     # Extract files
 
-    suffix = ''
     with zipfile.ZipFile(f) as zf:
         print('Extracting {0}...'.format(f))
-        zf.extractall(path=os.path.join(endf_files_dir, suffix))
+        zf.extractall(path=endf_files_dir)
 
 
 # ==============================================================================
 # GENERATE HDF5 LIBRARY -- NEUTRON FILES
 
 # Get a list of all ENDF files
-neutron_files = glob.glob(release_details[args.release]['neutron_files'])
+neutron_files = release_details[args.release]['neutron_files']
 
 # Create output directory if it doesn't exist
-if not os.path.isdir(args.destination):
-    os.mkdir(args.destination)
+args.destination.mkdir(parents=True, exist_ok=True)
 
 library = openmc.data.DataLibrary()
 
 for filename in sorted(neutron_files):
 
     # this is a fix for the CENDL 3.1 release where the 22-Ti-047.C31 and 5-B-010.C31 files contain non-ASCII characters
-    if library_name == 'cendl' and args.release == '3.1' and os.path.basename(filename) in  ['22-Ti-047.C31','5-B-010.C31']:
+    if library_name == 'cendl' and args.release == '3.1' and filename.name in  ['22-Ti-047.C31','5-B-010.C31']:
         print('Manual fix for incorrect value in ENDF file')
         text = open(filename, 'rb').read().decode('utf-8','ignore').split('\r\n')
-        if os.path.basename(filename) == '22-Ti-047.C31':
+        if filename.name == '22-Ti-047.C31':
             text[205] = ' 8) YUAN Junqian,WANG Yongchang,etc.               ,16,(1),57,92012228 1451  205'
-        if os.path.basename(filename) == '5-B-010.C31':
+        if filename.name == '5-B-010.C31':
             text[203] = '21)   Day R.B. and Walt M.  Phys.rev.117,1330 (1960)               525 1451  203'
         open(filename, 'w').write('\r\n'.join(text))
 
-    print('Converting: ' + filename)
+    print('Converting: ' + str(filename))
     data = openmc.data.IncidentNeutron.from_njoy(filename)
 
     # Export HDF5 file
-    h5_file = os.path.join(args.destination, data.name + '.h5')
+    h5_file = args.destination / f'{data.name}.h5'
     print('Writing {}...'.format(h5_file))
     data.export_to_hdf5(h5_file, 'w', libver=args.libver)
 
@@ -131,5 +128,4 @@ for filename in sorted(neutron_files):
     library.register_file(h5_file)
 
 # Write cross_sections.xml
-libpath = os.path.join(args.destination, 'cross_sections.xml')
-library.export_to_xml(libpath)
+library.export_to_xml(args.destination / 'cross_sections.xml')


### PR DESCRIPTION
This pull request contains changes related to item 10 in our list/issue 17 from the parent openmc-dev/data repository.

I've removed use of os.path from the following 5x convert/generate scripts:

- convert_fendl.py
- convert_jeff32.py
- convert_tendl.py
- generate_cendl.py
- generate_jendl.py

This includes replacing the use of the glob module for file searching with the Path.glob function.

I've not updated the following files:

- data_formatting_tools.py
- database_tools.py
- extract_entire_lib.py

As these were only created 10 days ago and appear to be a work in progress.

Testing was performed by running the original and modified scripts and performing the following checks:

- That the console logs produced by both scripts were identical
- That the files extracted before processing were identical
- That the number and size of hdf5 files created were identical
- That the cross_sections.xml files created were identical
- That a subset of created hdf5 files created contained identical data. This is done using the h5diff utility because hdf5 files report differences using diff.

Where the generate_* scripts take considerable time running njoy to process the downloaded data, these scripts were testing using specially created subsets of the downloaded data designed to test the different parts of the script. For the generate_cendl.py script this included the files which require file specific fixes.

